### PR TITLE
Fix caret jumping to end of line on truncation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,8 +221,7 @@
 
 
   <!-- JaVAVAVAVAVa -->
-  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
- <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/zepto/1.1.4/zepto.min.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -2,9 +2,13 @@ $( document ).ready(function() {
 
   truncAll();
 
-  $('.i2').on('keyup', _.debounce(function (e) {
+  $('.i2').on('keyup', function(e) {
+    if ([16, 37, 38, 39, 40].indexOf(e.which) >= 0) {
+      return;
+    }
+
     trunc($(this));
-  }, 200));
+  });
 
   $('.i1, .i2').on('mouseover', function(e){
     $(this).addClass('hover');
@@ -18,10 +22,12 @@ $( document ).ready(function() {
 
 function trunc(e){
   if (e.val().length > 40){
+    var selectionStart = e.get(0).selectionStart;
+
     e.val( e.val().substring(0, 39)+"..." );
-  } /*else {
-      e.val( e.val().replace(/...$/, '') );
-    }*/
+
+    e.get(0).setSelectionRange(selectionStart, selectionStart);
+  }
 }
 
 function truncAll(){


### PR DESCRIPTION
When I was using this, I noticed that as you are typing in the middle of the line, when truncation occurs, your caret is sent to the end of the line, like so:

http://g.recordit.co/QeHxfboMiX.gif

Therefore, this PR does two things. Remove the debounce, because I like instant results, but that's more subjective. Secondly, it stores your caret position before truncating, then truncates, then restores your caret position afterwards, like so:

http://g.recordit.co/N8qVgbrliA.gif

It seems like it would make it easier to use, but I'll let you be the judge of that. I was mostly just kind of bored/curious as to how to fix the caret issue.
